### PR TITLE
Start indicator in systemd when ayatana-indicators.target is started

### DIFF
--- a/data/ayatana-indicator-sound.service.in
+++ b/data/ayatana-indicator-sound.service.in
@@ -1,8 +1,11 @@
 [Unit]
 Description=Ayatana Indicator Sound Service
 PartOf=graphical-session.target
-After=ayatana-indicators-pre.target
+PartOf=ayatana-indicators.target
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ayatana-indicator-sound/ayatana-indicator-sound-service
 Restart=on-failure
+
+[Install]
+WantedBy=ayatana-indicators.target

--- a/debian/ayatana-indicator-sound.links
+++ b/debian/ayatana-indicator-sound.links
@@ -1,0 +1,2 @@
+# Because dh-systemd does not yet support user units, we manually make the WantedBy link
+/usr/lib/systemd/user/ayatana-indicator-sound.service /usr/lib/systemd/user/ayatana-indicators.target.wants/ayatana-indicator-sound.service

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: sound
 Priority: optional
 Maintainer: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
 Build-Depends: debhelper (>= 9.0),
+               dh-systemd,
                cmake,
                cmake-extras (>= 0.10),
                dbus,

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 export DPKG_GENSYMBOLS_CHECK_LEVEL=4
 
 %:
-	dh $@ --parallel --fail-missing
+	dh $@ --parallel --fail-missing --with systemd
 
 override_dh_auto_configure:
 	# Debian defines CMAKE_INSTALL_LOCALSTATEDIR as /usr/var, which is wrong.


### PR DESCRIPTION
This starts the indicator with the ayatana-indicators.target

Depends on AyatanaIndicators/libayatana-indicator#7