### PR TITLE
tests/*: Use one spelling for "Canonical Ltd." in copyright headers.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -82,7 +82,7 @@ Files: tests/dbus-types/dbus-action-result.cpp
  tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisMock.h
  tests/service-mocks/media-player-mpris-mock/main.cpp
  tests/service-mocks/media-player-mpris-mock/player-update.cpp
-Copyright: 2015, Canonical, Ltd.
+Copyright: 2015, Canonical Ltd.
 License: GPL-3
 
 Files: tests/integration/main.cpp

--- a/src/accounts-service-privacy-settings.vala
+++ b/src/accounts-service-privacy-settings.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 © Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/accounts-service-sound-settings.vala
+++ b/src/accounts-service-sound-settings.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 © Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/accounts-service-system-sound-settings.vala
+++ b/src/accounts-service-system-sound-settings.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 © Canonical Ltd.
- * Copyright 2021 © Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/accounts-service-user.vala
+++ b/src/accounts-service-user.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 © Canonical Ltd.
- * Copyright 2021 © Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/greeter-broadcast.vala
+++ b/src/greeter-broadcast.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 © Canonical Ltd.
- * Copyright 2021 © Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/media-player-list-greeter.vala
+++ b/src/media-player-list-greeter.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2014 Canonical Ltd.
- * Copyright © 2021 Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/media-player-list.vala
+++ b/src/media-player-list.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/media-player-user.vala
+++ b/src/media-player-user.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2014 Canonical Ltd.
- * Copyright © 2021 Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/media-player.vala
+++ b/src/media-player.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/volume-control.vala
+++ b/src/volume-control.vala
@@ -1,6 +1,6 @@
 /*
  * -*- Mode:Vala; indent-tabs-mode:t; tab-width:4; encoding:utf8 -*-
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/accounts-service-mock.h
+++ b/tests/accounts-service-mock.h
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2014 Canonical Ltd.
- * Copyright © 2021 Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/accounts-service-user.cc
+++ b/tests/accounts-service-user.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/dbus-types/dbus-action-result.cpp
+++ b/tests/dbus-types/dbus-action-result.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/dbus-types/dbus-action-result.h
+++ b/tests/dbus-types/dbus-action-result.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/dbus-types/dbus-types.h
+++ b/tests/dbus-types/dbus-types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/dbus-types/pulseaudio-volume.cpp
+++ b/tests/dbus-types/pulseaudio-volume.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/dbus-types/pulseaudio-volume.h
+++ b/tests/dbus-types/pulseaudio-volume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/greeter-list.cc
+++ b/tests/greeter-list.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/gtest-gvariant.h
+++ b/tests/gtest-gvariant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/indicator-fixture.h
+++ b/tests/indicator-fixture.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/indicator-test.cc
+++ b/tests/indicator-test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/integration/indicator-sound-test-base.cpp
+++ b/tests/integration/indicator-sound-test-base.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  * Copyright (C) 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/tests/integration/indicator-sound-test-base.h
+++ b/tests/integration/indicator-sound-test-base.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3,

--- a/tests/integration/test-indicator.cpp
+++ b/tests/integration/test-indicator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/integration/utils/dbus-pulse-volume.cpp
+++ b/tests/integration/utils/dbus-pulse-volume.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  * Copyright (C) 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/tests/integration/utils/dbus-pulse-volume.h
+++ b/tests/integration/utils/dbus-pulse-volume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/integration/utils/get-volume.cpp
+++ b/tests/integration/utils/get-volume.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/integration/utils/set-volume.cpp
+++ b/tests/integration/utils/set-volume.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/media-player-list-mock.vala
+++ b/tests/media-player-list-mock.vala
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/media-player-mock.vala
+++ b/tests/media-player-mock.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2014 Canonical Ltd.
- * Copyright © 2021 Robert Tari
+ * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/media-player-user.cc
+++ b/tests/media-player-user.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/notifications-mock.h
+++ b/tests/notifications-mock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/notifications-test.cc
+++ b/tests/notifications-test.cc
@@ -1,6 +1,6 @@
 /*
- * Copyright © 2015-2016 Canonical Ltd.
- * Copyright © 2021 Robert Tari
+ * Copyright 2015-2016 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/options-mock.vala
+++ b/tests/options-mock.vala
@@ -1,6 +1,6 @@
 /*
  * -*- Mode:Vala; indent-tabs-mode:t; tab-width:4; encoding:utf8 -*-
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/pa-mock.cpp
+++ b/tests/pa-mock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/service-mocks/DBusPropertiesNotifier.cpp
+++ b/tests/service-mocks/DBusPropertiesNotifier.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/DBusPropertiesNotifier.h
+++ b/tests/service-mocks/DBusPropertiesNotifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/accounts-mock/AccountsDefs.h
+++ b/tests/service-mocks/accounts-mock/AccountsDefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  * Copyright (C) 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/tests/service-mocks/accounts-mock/AccountsMock.cpp
+++ b/tests/service-mocks/accounts-mock/AccountsMock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/accounts-mock/AccountsMock.h
+++ b/tests/service-mocks/accounts-mock/AccountsMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/accounts-mock/AccountsServiceSoundMock.cpp
+++ b/tests/service-mocks/accounts-mock/AccountsServiceSoundMock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/accounts-mock/AccountsServiceSoundMock.h
+++ b/tests/service-mocks/accounts-mock/AccountsServiceSoundMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/accounts-mock/main.cpp
+++ b/tests/service-mocks/accounts-mock/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisDefs.h
+++ b/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisDefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  * Copyright (C) 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it

--- a/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisMock.cpp
+++ b/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisMock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisMock.h
+++ b/tests/service-mocks/media-player-mpris-mock/MediaPlayerMprisMock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/media-player-mpris-mock/main.cpp
+++ b/tests/service-mocks/media-player-mpris-mock/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/service-mocks/media-player-mpris-mock/player-update.cpp
+++ b/tests/service-mocks/media-player-mpris-mock/player-update.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Canonical, Ltd.
+ * Copyright (C) 2015 Canonical Ltd.
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published

--- a/tests/sound-menu.cc
+++ b/tests/sound-menu.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/volume-control-mock.vala
+++ b/tests/volume-control-mock.vala
@@ -1,6 +1,6 @@
 /*
  * -*- Mode:Vala; indent-tabs-mode:t; tab-width:4; encoding:utf8 -*-
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/volume-control-test.cc
+++ b/tests/volume-control-test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Canonical Ltd.
+ * Copyright 2014 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/volume-warning-mock.vala
+++ b/tests/volume-warning-mock.vala
@@ -1,6 +1,6 @@
 /*
  * -*- Mode:Vala; indent-tabs-mode:t; tab-width:4; encoding:utf8 -*-
- * Copyright © 2015 Canonical Ltd.
+ * Copyright 2015 Canonical Ltd.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
 Some license headers use "Canonical, Ltd." while others use "Canonical
 Ltd." as copyright holder. The correct form is the latter, so this
 change adjusts the spelling accordingly.

 This unification helps with generating debian/copyright files via
 scripts.