### PR TITLE
data/CMakeLists.txt: Drop unused pkglibexecdir definition

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -32,7 +32,6 @@ if (${SYSTEMD_FOUND})
   set (SYSTEMD_USER_FILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/${SYSTEMD_USER_NAME}.in")
 
   # build it
-  set (pkglibexecdir "${CMAKE_INSTALL_FULL_PKGLIBEXECDIR}")
   configure_file ("${SYSTEMD_USER_FILE_IN}" "${SYSTEMD_USER_FILE}")
 
   # install it


### PR DESCRIPTION
This currently fails to build - it should be fine after a rebase against the previous pull request.