### PR TITLE
src/*.vala: make the 'silent_mode' item & action QMenuModel compatible

### DIFF
--- a/src/service.vala
+++ b/src/service.vala
@@ -335,7 +335,7 @@ public class IndicatorSound.Service: Object {
             silentNow = this.accounts_service.silentMode;
         }
 
-        silent_action = new SimpleAction.stateful ("silent-mode", null, new Variant.boolean (silentNow));
+        silent_action = new SimpleAction.stateful ("silent-mode", VariantType.BOOLEAN, new Variant.boolean (silentNow));
 
         /* If we're not dealing with accounts service, we'll just always be out
            of silent mode and that's cool. */
@@ -349,7 +349,7 @@ public class IndicatorSound.Service: Object {
         });
 
         silent_action.activate.connect ((action, param) => {
-            action.change_state (new Variant.boolean (!action.get_state().get_boolean()));
+            action.change_state (param);
         });
 
         silent_action.change_state.connect ((action, val) => {

--- a/src/sound-menu.vala
+++ b/src/sound-menu.vala
@@ -51,7 +51,7 @@ public class SoundMenu: Object
         if ((flags & DisplayFlags.SHOW_MUTE) != 0)
             volume_section.append (_("Mute"), "indicator.mute");
         if ((flags & DisplayFlags.SHOW_SILENT_MODE) != 0) {
-            var item = new MenuItem(_("Silent Mode"), "indicator.silent-mode");
+            var item = new MenuItem(_("Silent Mode"), "indicator.silent-mode(true)");
             item.set_attribute("x-ayatana-type", "s", "org.ayatana.indicator.switch");
             volume_section.append_item(item);
         }


### PR DESCRIPTION
    QMenuModel, inheritting code from GTK, will consider the menu item not
    "activatable" if the item's "target" [1] doesn't match the corresponding
    action's parameter. Since we take a boolean as action's parameter (and
    we can't change action's parameter easily since it's semi-public), we
    instead have to pass "target".

    Taking a page from the slider menu items, pass "true" as the target
    will make QMenuModel considers the item activatable and reflect the
    right state.

    [1] i.e. the parameter to pass when activating the action. See
    https://wiki.gnome.org/Projects/GLib/GApplication/DBusAPI#Attributes

    Related: https://github.com/AyatanaIndicators/qmenumodel/issues/21