### PR TITLE
Ensure ayatana-indicator-sound is started after Pulseaudio

### DIFF
--- a/data/ayatana-indicator-sound.service.in
+++ b/data/ayatana-indicator-sound.service.in
@@ -2,6 +2,7 @@
 Description=Ayatana Indicator Sound Service
 PartOf=graphical-session.target
 PartOf=ayatana-indicators.target
+After=pulseaudio.service
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ayatana-indicator-sound/ayatana-indicator-sound-service


### PR DESCRIPTION
This is just to ensure correct startup order.

This is based on the upstart behavior in an override we had in ubuntu-touch-session which seems generally useful, see also: https://gitlab.com/ubports/development/core/ubuntu-touch-session/-/merge_requests/30/diffs?commit_id=2ca9a88fa819823148b38be7e6e2c7ffc1cafdfb#3d53b7175902f894e0c5a1b1dbd16fa95430d6d3_1_0