### PR TITLE
src/, tests/: update references to renamed notification hints

### DIFF
--- a/src/info-notification.vala
+++ b/src/info-notification.vala
@@ -30,7 +30,7 @@ public class IndicatorSound.InfoNotification: Notification
     public void show (VolumeControl.ActiveOutput active_output,
                       double volume,
                       bool is_high_volume) {
-        if (!notify_server_supports ("x-canonical-private-synchronous"))
+        if (!notify_server_supports ("x-lomiri-private-synchronous"))
             return;
 
         /* Determine Label */
@@ -44,7 +44,7 @@ public class IndicatorSound.InfoNotification: Notification
         n.update (_("Volume"), volume_label, icon);
         n.clear_hints();
         n.set_hint ("x-lomiri-non-shaped-icon", "true");
-        n.set_hint ("x-canonical-private-synchronous", "true");
+        n.set_hint ("x-lomiri-private-synchronous", "true");
         n.set_hint ("x-lomiri-value-bar-tint", is_high_volume ? "true" : "false");
         n.set_hint ("value", ((int32)((volume * 100.0) + 0.5)).clamp(0, 100));
         show_notification ();

--- a/tests/integration/indicator-sound-test-base.cpp
+++ b/tests/integration/indicator-sound-test-base.cpp
@@ -72,7 +72,7 @@ void IndicatorSoundTestBase::SetUp()
                             "GetCapabilities",
                             "",
                             "as",
-                            "ret = ['actions', 'body', 'body-markup', 'icon-static', 'image/svg+xml', 'x-canonical-private-synchronous', 'x-canonical-append', 'x-canonical-private-icon-only', 'x-canonical-truncation', 'private-synchronous', 'append', 'private-icon-only', 'truncation']"
+                            "ret = ['actions', 'body', 'body-markup', 'icon-static', 'image/svg+xml', 'x-lomiri-private-synchronous', 'x-canonical-append', 'x-lomiri-private-icon-only', 'x-lomiri-truncation', 'x-canonical-truncation', 'private-synchronous', 'append', 'private-icon-only', 'truncation']"
                          ).waitForFinished();
 
     int waitedTime = 0;
@@ -649,12 +649,12 @@ void IndicatorSoundTestBase::checkVolumeNotification(double volume, QString cons
     ASSERT_TRUE(hints.contains("value"));
     ASSERT_TRUE(hints.contains("x-lomiri-non-shaped-icon"));
     ASSERT_TRUE(hints.contains("x-lomiri-value-bar-tint"));
-    ASSERT_TRUE(hints.contains("x-canonical-private-synchronous"));
+    ASSERT_TRUE(hints.contains("x-lomiri-private-synchronous"));
 
     EXPECT_EQ(volume*100, hints["value"]);
     EXPECT_EQ(true, hints["x-lomiri-non-shaped-icon"]);
     EXPECT_EQ(isLoud, hints["x-lomiri-value-bar-tint"]);
-    EXPECT_EQ(true, hints["x-canonical-private-synchronous"]);
+    EXPECT_EQ(true, hints["x-lomiri-private-synchronous"]);
 }
 
 void IndicatorSoundTestBase::checkHighVolumeNotification(QVariantList call)

--- a/tests/notifications-mock.h
+++ b/tests/notifications-mock.h
@@ -31,7 +31,7 @@ class NotificationsMock
         DbusTestDbusMockObject * baseobj = nullptr;
 
     public:
-        NotificationsMock (const std::vector<std::string>& capabilities = {"actions", "body", "body-markup", "icon-static", "image/svg+xml", "x-canonical-private-synchronous", "x-canonical-append", "x-canonical-private-icon-only", "x-canonical-truncation", "private-synchronous", "append", "private-icon-only", "truncation"}) {
+        NotificationsMock (const std::vector<std::string>& capabilities = {"actions", "body", "body-markup", "icon-static", "image/svg+xml", "x-lomiri-private-synchronous", "x-canonical-append", "x-lomiri-private-icon-only", "x-lomiri-truncation", "x-canonical-truncation", "private-synchronous", "append", "private-icon-only", "truncation"}) {
             mock = dbus_test_dbus_mock_new("org.freedesktop.Notifications");
             dbus_test_task_set_bus(DBUS_TEST_TASK(mock), DBUS_TEST_SERVICE_BUS_SESSION);
             dbus_test_task_set_name(DBUS_TEST_TASK(mock), "Notify");

--- a/tests/notifications-test.cc
+++ b/tests/notifications-test.cc
@@ -259,7 +259,7 @@ TEST_F(NotificationsTest, VolumeChanges) {
     EXPECT_EQ("ayatana-indicator-sound", notev[0].app_name);
     EXPECT_EQ("Volume", notev[0].summary);
     EXPECT_EQ(0, notev[0].actions.size());
-    EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-canonical-private-synchronous"]);
+    EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-lomiri-private-synchronous"]);
     EXPECT_GVARIANT_EQ("@i 50", notev[0].hints["value"]);
 
     /* Set a different volume */
@@ -513,7 +513,7 @@ TEST_F(NotificationsTest, DISABLED_ExtendendVolumeNotification) {
     EXPECT_EQ("ayatana-indicator-sound", notev[0].app_name);
     EXPECT_EQ("Volume", notev[0].summary);
     EXPECT_EQ(0, notev[0].actions.size());
-    EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-canonical-private-synchronous"]);
+    EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-lomiri-private-synchronous"]);
     EXPECT_GVARIANT_EQ("@i 50", notev[0].hints["value"]);
 
     /* Allow an amplified volume */
@@ -629,13 +629,13 @@ TEST_F(NotificationsTest, DISABLED_TriggerWarning) {
             EXPECT_TRUE(volume_warning_get_active(volumeWarning.get()));
             ASSERT_EQ(1, notev.size());
             EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-lomiri-snap-decisions"]);
-            EXPECT_GVARIANT_EQ(nullptr, notev[0].hints["x-canonical-private-synchronous"]);
+            EXPECT_GVARIANT_EQ(nullptr, notev[0].hints["x-lomiri-private-synchronous"]);
         }
         else {
             EXPECT_FALSE(volume_warning_get_active(volumeWarning.get()));
             ASSERT_EQ(1, notev.size());
             EXPECT_GVARIANT_EQ(nullptr, notev[0].hints["x-lomiri-snap-decisions"]);
-            EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-canonical-private-synchronous"]);
+            EXPECT_GVARIANT_EQ("@s 'true'", notev[0].hints["x-lomiri-private-synchronous"]);
         }
 
     } // multimedia_active


### PR DESCRIPTION
More notification hints have been renamed. So update to follow it.

- x-canonical-private-synchronous -> x-lomiri-private-synchronous
- x-canonical-private-icon-only -> x-lomiri-private-icon-only
- x-canonical-truncation -> x-lomiri-truncation (which Lomiri has compatibility with the former name, so keep in the mocked capabilities)