### PR TITLE
src, tests: fix -Wint-to-pointer-cast and a chance of test crash

### DIFF
--- a/src/volume-control.vala
+++ b/src/volume-control.vala
@@ -54,7 +54,7 @@ public abstract class VolumeControl : Object
 
 	protected IndicatorSound.Options _options = null;
 
-	internal VolumeControl(IndicatorSound.Options options) {
+	protected VolumeControl(IndicatorSound.Options options) {
 		_options = options;
 	}
 

--- a/src/volume-warning.vala
+++ b/src/volume-warning.vala
@@ -44,7 +44,7 @@ public abstract class VolumeWarning : Object
         }
     }
 
-    internal VolumeWarning (IndicatorSound.Options options) {
+    protected VolumeWarning (IndicatorSound.Options options) {
 
         _options = options;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,8 +83,8 @@ vala_init(vala-mocks
 set_source_files_properties(media-player-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-warning-option -Wno-incompatible-pointer-types -Wno-discarded-qualifiers")
 set_source_files_properties(media-player-list-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types -Wno-unused-variable")
 set_source_files_properties(options-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types -Wno-unused-variable")
-set_source_files_properties(volume-control-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types -Wno-int-to-pointer-cast -Wno-implicit-function-declaration")
-set_source_files_properties(volume-warning-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-implicit-function-declaration")
+set_source_files_properties(volume-control-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types")
+set_source_files_properties(volume-warning-mock.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-incompatible-pointer-types -Wno-unused-variable")
 
 vala_add(vala-mocks
     media-player-mock.vala


### PR DESCRIPTION
Turns the constructor of `VolumeControl` and `VolumeWarning` from `internal` to `protected`. This makes Vala emits C declaration of constructors, which is required by the test's mocks extending these classes, in the external header.

Without them, the mocks' C code would then consider them "implicitly declared", and will assume they return `int` instead of a pointer. If the returned address happened to be higher than `INT_MAX`, the code will consider the returned address negative and sign-extend it when casting to a pointer, corrupting it.

As for "unprivating" these constructors, this is an internal static library anyway. No libraries or headers are installed from this package. This change is invisible from outside.